### PR TITLE
Expand README and add runbook documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,76 +1,209 @@
 # Invoice Anomaly Sieve
 
-Invoice Anomaly Sieve detects duplicate or anomalous vendor invoices. It exposes a FastAPI service
-for scoring invoices, routing suspect items to review, and maintaining audit trails. The
-implementation follows the requirements and architecture documents in this repository.
+Invoice Anomaly Sieve is a FastAPI service that scores vendor invoices for duplicate or anomalous
+behavior, routes suspect items to review, and maintains auditable decision trails. The project
+implements the requirements and architecture captured in [`requirements.md`](requirements.md) and
+[`architecture.md`](architecture.md) while providing a runnable reference stack for local
+development and testing.
 
-## Features
+## Table of contents
 
-- FastAPI scoring endpoint that ingests invoices, normalizes fields, computes candidate matches,
-  and fuses duplicate/anomaly signals into a unified risk score.
-- Deterministic rules (same invoice number, PO near total, PDF hash, bank change) with configurable
-  thresholds.
-- Feature engineering for header similarity, line-item assignment, and lightweight text similarity.
-- Persistence in PostgreSQL with idempotent invoice storage, audit logs, and case creation.
-- Vendor-specific anomaly detection heuristics and bank account change monitoring.
-- Scripts to initialize local infrastructure, train baseline models, backfill decisions, and compute
-  vendor baselines.
+- [Overview](#overview)
+- [Key capabilities](#key-capabilities)
+- [Core architecture and data flow](#core-architecture-and-data-flow)
+- [Local development quickstart](#local-development-quickstart)
+- [Repository layout](#repository-layout)
+- [Configuration](#configuration)
+- [Operational dependencies](#operational-dependencies)
+- [API surfaces](#api-surfaces)
+- [Models and offline jobs](#models-and-offline-jobs)
+- [Quality and testing](#quality-and-testing)
+- [Observability and logs](#observability-and-logs)
+- [Additional documentation](#additional-documentation)
+
+## Overview
+
+The service receives invoice payloads, normalizes and enriches the data, retrieves historical
+candidates from storage and search, computes pairwise similarity features, and combines deterministic
+rules with machine learning scores to produce a final risk score and action. Persisted decisions,
+audit logs, and case artifacts ensure every outcome can be reconstructed for compliance purposes.
+
+## Key capabilities
+
+- **Real-time scoring** – `POST /scoreInvoice` ingests an invoice, applies normalization, retrieves
+  historical candidates, and fuses rule, duplicate, and anomaly signals into a 0–100 risk score.
+- **Rules-first decisioning** – deterministic duplicate and fraud heuristics execute before ML
+  scoring and can force HOLD/REVIEW outcomes when thresholds are breached.
+- **Vendor-aware anomaly detection** – vendor baselines capture historical behavior to detect amount
+  outliers and bank account changes.
+- **Persistent audit trail** – invoices, candidate pairs, decisions, cases, and audit entries are
+  stored in PostgreSQL so decisions are reproducible.
+- **Extensible offline workflows** – scripts train and refresh models, seed infrastructure, and
+  replay historical invoices for backfills.
+
+## Core architecture and data flow
+
+The codebase maps to the layered architecture described in `architecture.md`:
+
+1. **Ingestion & persistence** (`app/main.py`, `app/normalization.py`, `app/storage.py`) validate the
+   payload, compute normalized fields, and store invoices, lines, and vendor remit accounts.
+2. **Candidate retrieval** (`app/retrieval.py`) queries PostgreSQL for structured blocks (amount,
+   PO, bank account hash, invoice number). Optional OpenSearch indexing is used for near-text
+   retrieval when configured.
+3. **Feature engineering** (`app/features.py`) computes header, line-level, and text similarity
+   metrics used by the duplicate model.
+4. **Duplicate scoring** (`app/duplicate_model.py`) loads a trained logistic regression model when
+   available or falls back to heuristic weights.
+5. **Anomaly scoring** (`app/anomaly.py`) evaluates vendor-specific baselines, unit price outliers,
+   and bank account changes.
+6. **Decisioning & cases** (`app/decision.py`, `app.rules`, `app.case`, `app.audit`) fuse signals,
+   apply thresholds, and persist audit trails and review cases.
+
+A nightly batch path (see `scripts/` and `models/`) supports vendor baseline refreshes, duplicate
+model training, and backfill scoring.
+
+## Local development quickstart
+
+### Prerequisites
+
+- Python 3.11+
+- Docker (for PostgreSQL, Redis, MinIO, OpenSearch, Redpanda, MLflow)
+- `make`, `curl`, and `jq`
+
+### Environment setup
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install --upgrade pip
+pip install -e .[dev]
+```
+
+### Start local dependencies
+
+```bash
+docker compose -f ops/docker-compose.yaml up -d
+make init  # creates database schema, object storage bucket, and OpenSearch index
+```
+
+### Run the API locally
+
+```bash
+uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload
+```
+
+### Smoke test the scoring endpoint
+
+```bash
+curl -s -X POST http://localhost:8080/scoreInvoice \
+  -H "Authorization: Bearer devtoken" \
+  -H "Content-Type: application/json" \
+  -d @samples/invoice_example.json | jq
+```
+
+### Shut down infrastructure
+
+```bash
+docker compose -f ops/docker-compose.yaml down
+```
 
 ## Repository layout
 
-See [`implementation.md`](implementation.md) for the authoritative structure. Key folders:
+| Path | Purpose |
+| --- | --- |
+| `app/` | FastAPI application modules (API entrypoint, config, storage, feature engineering, rules, anomaly, duplicate model, cases, audit). |
+| `models/` | Model artifacts such as the trained duplicate model (`dup_model.joblib`). |
+| `ops/` | Docker Compose definitions and environment files for local infrastructure. |
+| `samples/` | Example invoice payloads for manual testing. |
+| `scripts/` | Operational scripts to initialize storage, train models, compute vendor baselines, and backfill decisions. |
+| `tests/` | Unit tests covering normalization, rules, features, and decision fusion. |
+| `Makefile` | Convenience targets for initialization (`make init`), formatting (`make fmt`), and tests (`make test`). |
 
-- `app/` – FastAPI application modules and SQL schema.
-- `scripts/` – Utilities for initializing infra and running training/backfill jobs.
-- `ops/` – Docker Compose and environment files for local dependencies.
-- `tests/` – Unit tests that exercise normalization, rules, features, and decision logic.
-- `samples/` – Example invoice payloads for manual testing.
+For the authoritative blueprint, refer to [`implementation.md`](implementation.md).
 
-## Getting started
+## Configuration
 
-1. Create a virtual environment and install dependencies:
-   ```bash
-   python -m venv .venv && source .venv/bin/activate
-   pip install --upgrade pip
-   pip install -e .[dev]
-   ```
-2. Start local infrastructure:
-   ```bash
-   docker compose -f ops/docker-compose.yaml up -d
-   ```
-3. Initialize storage targets and indices:
-   ```bash
-   make init
-   ```
-4. Run the API:
-   ```bash
-   uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload
-   ```
-5. Score an invoice:
-   ```bash
-   curl -s -X POST http://localhost:8080/scoreInvoice \
-     -H "Authorization: Bearer devtoken" \
-     -H "Content-Type: application/json" \
-     -d @samples/invoice_example.json | jq
-   ```
+Runtime behavior is controlled via environment variables parsed in `app/config.py`:
 
-## Development
+| Variable | Default | Description |
+| --- | --- | --- |
+| `APP_ENV` | `dev` | Environment label used for logging and behavior toggles. |
+| `DB_DSN` | `postgresql+psycopg://postgres:postgres@localhost:5432/sieve` | SQLAlchemy DSN for PostgreSQL. |
+| `REDIS_URL` | `redis://localhost:6379/0` | Redis URL for caching and feature storage. |
+| `S3_ENDPOINT`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_BUCKET` | — | Object storage connection for raw invoice payloads and model artifacts. |
+| `OS_HOST` | `http://localhost:9200` | OpenSearch endpoint for near-text retrieval. |
+| `MLFLOW_TRACKING_URI` | `http://localhost:5001` | MLflow tracking server used for model lineage. |
+| `TENANT_ID` | `tenant_demo` | Current tenant identifier applied to all persisted records. |
+| `JWT_SECRET`, `JWT_AUDIENCE`, `JWT_ISSUER` | — | Authentication parameters for JWT validation. |
+| `HOLD_THRESHOLD_DEFAULT`, `REVIEW_THRESHOLD_DEFAULT` | `80`, `50` | Default risk score thresholds applied when vendor overrides are absent. |
+| `DUP_MODEL_PATH` | `models/dup_model.joblib` | Path to the duplicate model artifact; if missing, heuristic fallback weights apply. |
 
-- `make fmt` runs Ruff autofix and a best-effort mypy pass.
-- `make test` executes the unit test suite.
-- `scripts/train_duplicate.py` derives weak labels from stored invoices to train a logistic regression
-  duplicate detector. The model artifact is saved to `models/dup_model.joblib` and automatically
-  loaded by the API.
-- `scripts/train_anomaly.py` calculates vendor amount baselines and stores them for online use.
-- `scripts/backfill_score.py` replays historical invoices and persists refreshed decisions.
+## Operational dependencies
 
-## Security & operations
+Local development relies on the services defined in `ops/docker-compose.yaml`:
 
-- Authentication uses a local JWT stub for development; replace with your SSO provider before
-  production use.
-- Tenant isolation is enforced via scoped queries using the configured `TENANT_ID`.
-- Audit logs capture every scoring action. Decisions and cases are immutable records with timestamps
-  for compliance traceability.
+- **PostgreSQL 16** – decision store, invoice metadata, cases, vendor baselines (`scripts/init_db.py`).
+- **Redis 7** – caching layer for hot features (optional during unit tests).
+- **MinIO** – S3-compatible object store for raw invoice blobs and MLflow artifacts (`scripts/init_s3.py`).
+- **OpenSearch 2.13** – near-text retrieval index seeded via `scripts/init_search.py`.
+- **Redpanda** – Kafka-compatible event bus placeholder for asynchronous flows.
+- **MLflow** – experiment tracking and model registry.
 
-Refer to `requirements.md` and `architecture.md` for the full specification and rationale behind the
-components delivered here.
+Each service exposes a health check in Compose and is required for end-to-end scoring parity with the
+architecture document.
+
+## API surfaces
+
+### `POST /scoreInvoice`
+
+Synchronously score a single invoice.
+
+- **Auth** – Bearer token, with `devtoken` accepted for local development.
+- **Request body** – conforms to `app.models.InvoiceIn` and includes header fields, vendor metadata,
+  line items, and optional attachments.
+- **Response** – `app.models.ScoreResponse` containing:
+  - `risk_score` – fused 0–100 risk score.
+  - `decision` – `PASS`, `REVIEW`, or `HOLD`.
+  - `reason_codes` – deterministic rules and anomaly components triggered during scoring.
+  - `top_matches` – candidate invoices contributing to the decision.
+  - `trace_id` – identifier for correlating logs and audit entries.
+
+Additional API contracts (`bulkScore`, `decision`, webhooks) are specified in
+[`architecture.md`](architecture.md) for future expansion.
+
+## Models and offline jobs
+
+Offline workflows live in `scripts/` and `models/`:
+
+- `scripts/train_duplicate.py` – trains or refreshes the logistic regression duplicate detector using
+  historical invoices stored in PostgreSQL. Results are saved to `models/dup_model.joblib` by default.
+- `scripts/train_anomaly.py` / `scripts/calc_vendor_baselines.py` – compute vendor-level amount
+  baselines used by `app.anomaly.anomaly_score`.
+- `scripts/backfill_score.py` – replays historical invoices through the scoring stack to recompute
+  decisions, useful after model or rules changes.
+- `scripts/init_*` – idempotent setup for database schema, OpenSearch index, and object storage.
+
+Model and data lineage are recorded in MLflow when `MLFLOW_TRACKING_URI` points at a running
+tracking server.
+
+## Quality and testing
+
+- `make fmt` – runs Ruff for linting with autofix and a best-effort mypy type check.
+- `make test` – executes the unit test suite (`pytest`).
+- Tests focus on deterministic behaviors (normalization, feature calculations, rule firing, decision
+  fusion) to keep the reference implementation verifiable.
+
+## Observability and logs
+
+- Structured logs include `tenant_id`, `invoice_id`, and `trace_id` fields for correlation.
+- Metrics recommended by the architecture include per-stage latency, candidate fan-out, duplicate
+  recall, reviewer precision, and drift indicators. Surface these via your observability stack when
+  deploying beyond local development.
+- Audit logs created through `app.audit.log_action` capture scoring operations, decisions, and case
+  actions for compliance review.
+
+## Additional documentation
+
+- [`architecture.md`](architecture.md) – system design, data flow, and platform considerations.
+- [`implementation.md`](implementation.md) – detailed implementation plan and file-by-file guidance.
+- [`requirements.md`](requirements.md) – functional and non-functional requirements.
+- [`runbook.md`](runbook.md) – operational procedures, monitoring, and incident response guidance.

--- a/runbook.md
+++ b/runbook.md
@@ -1,0 +1,205 @@
+# Invoice Anomaly Sieve Runbook
+
+This runbook documents day-2 operations for the Invoice Anomaly Sieve scoring service. It covers
+monitoring, routine procedures, and incident response for the FastAPI API, supporting services, and
+offline jobs.
+
+## Service summary
+
+| Item | Detail |
+| --- | --- |
+| **Service** | Invoice Anomaly Sieve |
+| **Description** | Scores vendor invoices for duplicate/anomalous behavior and routes suspect cases to review. |
+| **Owners** | Finance Ops Engineering (primary), Data/ML Platform (secondary). |
+| **Runtime** | Python 3.11, FastAPI, uvicorn (`app/main.py`). |
+| **Default port** | 8080 |
+| **Authentication** | JWT bearer token validated by `app.security.require_auth`; `devtoken` bypass for local usage. |
+| **Data stores** | PostgreSQL, Redis, MinIO (S3), OpenSearch, MLflow, Redpanda (Kafka-compatible). |
+| **Critical dependencies** | `app/storage.py` configured DSNs and clients, Docker services from `ops/docker-compose.yaml`. |
+| **Documentation** | [`README.md`](README.md), [`architecture.md`](architecture.md), [`implementation.md`](implementation.md). |
+
+## On-call daily checklist
+
+1. Confirm API health from the load balancer or uptime monitor (expect <200 ms p95 in steady state).
+2. Review latency, candidate fan-out, and error-rate dashboards.
+3. Check drift and model health alerts (duplicate ROC-AUC shadow eval, anomaly false hold rate).
+4. Verify overnight batch jobs (vendor baselines, duplicate training, backfills) completed and
+   uploaded results to MLflow / object storage.
+5. Skim audit logs for unusual HOLD surge or bank-change spikes.
+
+## Environments
+
+| Environment | Notes |
+| --- | --- |
+| **Local / Dev** | Run via `uvicorn app.main:app --reload`; dependencies launched with `docker compose -f ops/docker-compose.yaml up -d`. |
+| **Stage** | Mirrors production DSN/queues with smaller datasets; use for release validation and replay tests. |
+| **Prod** | Multi-AZ deployment, autoscaling, strict RBAC, TLS termination at gateway. |
+
+## Runtime operations
+
+### Start / stop the service
+
+```bash
+# Start (local/dev example)
+uvicorn app.main:app --host 0.0.0.0 --port 8080 --workers 4
+
+# Stop (Ctrl+C or orchestrator scale-down)
+```
+
+In Kubernetes, ensure liveness probes call `GET /healthz` (add if absent) and readiness probes check
+database connectivity.
+
+### Verify scoring end-to-end
+
+1. Insert or identify a sample invoice payload (e.g., `samples/invoice_example.json`).
+2. Call the API:
+   ```bash
+   curl -s -X POST http://<host>:8080/scoreInvoice \
+     -H "Authorization: Bearer <token>" \
+     -H "Content-Type: application/json" \
+     -d @samples/invoice_example.json | jq
+   ```
+3. Confirm response includes `risk_score`, `decision`, and non-empty `trace_id`.
+4. Query PostgreSQL to ensure the invoice and decision rows were persisted:
+   ```sql
+   SELECT decision, risk_score FROM decisions WHERE invoice_id='<invoice_id>';
+   ```
+
+### Initialize or rebuild infrastructure
+
+Run the bundled scripts when onboarding a new environment or after destructive maintenance:
+
+```bash
+make init  # runs scripts/init_db.py, scripts/init_s3.py, scripts/init_search.py
+```
+
+Individual components:
+
+- `python scripts/init_db.py` – executes `app/schema.sql` to create tables/indexes.
+- `python scripts/init_s3.py` – ensures the MinIO/S3 bucket exists for invoice blobs.
+- `python scripts/init_search.py` – recreates the `invoice_text` OpenSearch index using the template
+  in `app/index_templates/invoices_text.json`.
+
+### Configuration changes
+
+- Runtime configuration is sourced from environment variables in `app/config.py` (DB_DSN, REDIS_URL,
+  thresholds, tenant ID, JWT params).
+- Persist configuration overrides in your secrets manager / deployment manifests; changes require a
+  rolling restart.
+- Threshold changes (`HOLD_THRESHOLD_DEFAULT`, `REVIEW_THRESHOLD_DEFAULT`) should be coordinated with
+  Finance operations to avoid unexpected HOLD volume.
+
+## Batch and model operations
+
+### Duplicate model refresh
+
+1. Ensure recent invoices and reviewer dispositions are loaded in PostgreSQL.
+2. Run the trainer:
+   ```bash
+   python scripts/train_duplicate.py
+   ```
+3. Validate the console output for ROC-AUC / Average Precision metrics.
+4. Upload the resulting artifact (`models/dup_model.joblib` by default) to the model registry or ship
+   with the deployment package.
+5. Restart API pods to load the new model (cached by `app.duplicate_model.load_model`).
+
+If the trainer reports "Not enough labeled data" the service falls back to heuristic weights, which
+is acceptable for low-volume tenants.
+
+### Vendor anomaly baseline refresh
+
+```bash
+python scripts/train_anomaly.py
+python scripts/calc_vendor_baselines.py
+```
+
+These scripts compute and persist `vendor_amount_baselines` used by `app.anomaly.anomaly_score`.
+Schedule nightly; rerun manually if large vendor behavior shifts occur.
+
+### Backfill decisions
+
+Use `scripts/backfill_score.py` to rescore historical invoices after significant logic changes. Run
+per tenant or date range to control load and confirm database capacity before launching.
+
+## Monitoring and alerts
+
+Recommended telemetry (align with architecture section 18):
+
+- **Latency** – overall API, candidate retrieval, feature computation, duplicate model scoring,
+  anomaly scoring, decision persistence.
+- **Fan-out** – number of candidate invoices per request; alert if consistently >200 (retrieval cap).
+- **Rules vs ML mix** – rate of HOLD/REVIEW triggered by rules vs models; sudden shifts may indicate
+  drift or misconfiguration.
+- **Duplicate precision/recall** – track via shadow evaluation on adjudicated cases; degrade triggers
+  model retraining or threshold tuning.
+- **Bank change rate** – proportion of invoices flagged with `BANK_CHANGE` reason codes.
+- **Infrastructure** – DB connections, Redis latency, OpenSearch cluster health, MLflow availability,
+  S3 bucket errors.
+
+Log aggregation should preserve `tenant_id`, `invoice_id`, and `trace_id` from request contexts for
+correlation. Persisted audit logs via `app.audit.log_action` support SOX evidence and should be
+forwarded to cold storage.
+
+## Incident response playbooks
+
+### API returning 5xx or timing out
+
+1. Check service logs for traceback; 5xx often stem from database connectivity issues.
+2. Validate PostgreSQL availability (connection limits, replication lag). Restart session pods if
+   necessary.
+3. Inspect Redis and OpenSearch; if optional dependencies are down, expect degraded functionality but
+   API should continue (search writes are wrapped in try/except).
+4. If degradation persists, route traffic to a standby deployment or enable maintenance mode.
+
+### Database initialization or migration failure
+
+1. Re-run `python scripts/init_db.py` and inspect output for offending SQL statement.
+2. Ensure the deployment identity has privileges to create schemas, indices, and run idempotent
+   `INSERT ... ON CONFLICT` statements defined in `app/schema.sql`.
+3. On production, apply migrations via a controlled Alembic revision and double-write if downtime
+   would violate SLOs.
+
+### Search index unhealthy
+
+1. OpenSearch issues surface as increased candidate miss rates and drop in duplicate detection.
+2. Check cluster health via `_cluster/health`; if red, restart the node or fail over.
+3. Recreate the index using `python scripts/init_search.py` after confirming data retention (only
+   derived text is stored, so rebuild is safe).
+4. During outage, scoring continues using structured blocking with reduced recall.
+
+### High false HOLD rate / model drift
+
+1. Review drift dashboards (PSI/KS per vendor) and rule hit distribution.
+2. Confirm recent config or threshold changes; revert if misapplied.
+3. Trigger duplicate trainer and anomaly baseline refresh; deploy new artifacts after validation.
+4. If precision remains poor, temporarily raise HOLD threshold or enable rules-only mode by removing
+   the model artifact (`models/dup_model.joblib`) so the fallback heuristics run.
+
+### Bank account spoofing incident
+
+1. Identify impacted vendor and invoices (audit reason code `BANK_CHANGE`).
+2. Freeze payments externally if needed.
+3. Verify vendor remit accounts in `vendor_remit_accounts` table for abnormal churn.
+4. Coordinate with Finance to validate bank changes and update allow-lists.
+
+## Disaster recovery
+
+- **Database** – restore from latest PITR snapshot; replay `invoice.decided` events or audit logs to
+  rebuild downstream systems.
+- **Object storage** – S3/MinIO buckets use versioning; recover prior payloads if ingestion corrupted
+  data.
+- **Search** – rebuild index from PostgreSQL using `scripts/init_search.py` and `text_blob` helper in
+  `app.normalization`.
+- **Models** – fetch previous approved artifact from MLflow registry and redeploy.
+
+Document failover drills annually and validate that rules-only mode maintains minimum viable fraud
+coverage when ML services are offline.
+
+## Support and escalation
+
+- Pager rotation: Finance Ops Eng (primary), Data/ML Platform (secondary).
+- Slack: `#finops-invoice-sieve` (primary), `#ml-platform` (model support).
+- Email: invoice-sieve-oncall@company.example.
+- Vendor support: escalate to Procurement Ops if supplier master data is stale.
+
+Record all incidents in the team's tracker with postmortem templates referencing this runbook.


### PR DESCRIPTION
## Summary
- replace the README with a detailed overview of the architecture, setup steps, configuration, and API usage
- add an operations-focused runbook covering procedures, monitoring, and incident response for the service

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68cedb1d107883219460f6d83ce899a5